### PR TITLE
ipc_router: Bind only a client port as control port (fix CVE-2016-2059)

### DIFF
--- a/arch/arm/mach-msm/ipc_router.c
+++ b/arch/arm/mach-msm/ipc_router.c
@@ -2853,7 +2853,7 @@ int msm_ipc_router_get_curr_pkt_size(struct msm_ipc_port *port_ptr)
 
 int msm_ipc_router_bind_control_port(struct msm_ipc_port *port_ptr)
 {
-	if (!port_ptr)
+	if (unlikely(!port_ptr || port_ptr->type != CLIENT_PORT))
 		return -EINVAL;
 
 	down_write(&local_ports_lock_lha2);


### PR DESCRIPTION
IPC Router binds any port as a control port and moves it from the client
port list to control port list. Misbehaving clients can exploit this
incorrect behavior.

IPC Router to check if the port is a client port before binding it as a
control port.

Signed-off-by: CheckYourScreen nimitmehta95@gmail.com
